### PR TITLE
✨ Agregar middleware notFound para manejo de rutas 404

### DIFF
--- a/middlewares/joyas.middlewares.js
+++ b/middlewares/joyas.middlewares.js
@@ -53,11 +53,15 @@ const notFound = () => (req, res) => {
 };
 
 /**
- * Express error-handling middleware.
+ * Middleware de manejo de errores para Express.
  *
- * Logs the error message and stack trace, then sends a generic 500 response.
+ * Registra en el logger el mensaje y el stack trace del error recibido,
+ * y responde al cliente con un estado HTTP 500 y un mensaje genérico.
  *
- * @returns {ErrorRequestHandler} The error-handling middleware function.
+ * Este middleware debe ubicarse después de todas las rutas y middlewares
+ * para capturar errores no controlados durante el procesamiento de solicitudes.
+ *
+ * @returns {ErrorRequestHandler} Middleware para manejo de errores.
  */
 const errorHandler = () => (err, _req, res, _next) => {
   logger.error(`${err.message}\n${err.stack}`);

--- a/middlewares/joyas.middlewares.js
+++ b/middlewares/joyas.middlewares.js
@@ -41,6 +41,18 @@ const log = () => (req, res, next) => {
 };
 
 /**
+ * Middleware para rutas no encontradas (404).
+ *
+ * Registra una advertencia y responde con JSON indicando ruta no encontrada.
+ *
+ * @returns {RequestHandler}
+ */
+const notFound = () => (req, res) => {
+  logger.warn(`404 - Route not found - ${req.method} ${req.originalUrl}`);
+  res.status(404).json({ error: 'Route not found' });
+};
+
+/**
  * Express error-handling middleware.
  *
  * Logs the error message and stack trace, then sends a generic 500 response.
@@ -56,4 +68,4 @@ const errorHandler = () => (err, _req, res, _next) => {
   });
 };
 
-export default { log, errorHandler };
+export default { log, notFound, errorHandler };

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ app.use(cors());
 app.use(joyasMiddlewares.log());
 
 app.use(joyasRoutes);
+app.use(joyasMiddlewares.notFound());
 
 app.use(joyasMiddlewares.errorHandler());
 


### PR DESCRIPTION
Este PR agrega un nuevo middleware personalizado llamado `notFound`, encargado de manejar todas las solicitudes que no coincidan con ninguna ruta definida en la aplicación.
- Devuelve una respuesta con estado `404` y un mensaje JSON: `{ error: 'Route not found' }`.
- Registra un mensaje de advertencia (`warn`) en el logger con el método HTTP y la URL solicitada.
- Se ubica **después de todas las rutas y antes del errorHandler** para interceptar rutas no existentes correctamente.

✍️ Propósito
Cumple con buenas prácticas de Express al manejar rutas no encontradas con un middleware específico, mejorando la experiencia del desarrollador y del usuario ante errores de navegación.