### PR TITLE
✨ Agregar uso de pg-format para formatear consultas SQL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "tienda-de-joyas",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tienda-de-joyas",
-      "version": "1.0.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "pg": "^8.16.0",
+        "pg-format": "^1.0.4",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -3852,6 +3853,15 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
       "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
       "license": "MIT"
+    },
+    "node_modules/pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "pg": "^8.16.0",
+    "pg-format": "^1.0.4",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/src/models/joyas.model.js
+++ b/src/models/joyas.model.js
@@ -1,3 +1,5 @@
+import format from 'pg-format';
+
 import { config } from '../../config/joyas.config.js';
 
 import pool from '../../db/config.js';
@@ -33,16 +35,15 @@ export const getAllJoyasModel = async ({ limits, page, orderBy } = {}) => {
     defaultOrderBy
   );
 
-  const queryCountAllJoyas = {
-    text: 'SELECT COUNT(*) FROM inventario',
-  };
-  const querySelectAllJoyasWithParams = {
-    text: `SELECT * FROM inventario ORDER BY ${orderByColumn} ${orderByDirection} LIMIT $1 OFFSET $2`,
-    values: [limit, offset],
-  };
-  logger.info(
-    `Executed query: SELECT * FROM inventario ORDER BY ${orderByColumn} ${orderByDirection} LIMIT ${limit} OFFSET ${offset}`
+  const queryCountAllJoyas = format('SELECT COUNT(*) FROM inventario');
+  const querySelectAllJoyasWithParams = format(
+    'SELECT * FROM inventario ORDER BY %s %s LIMIT %s OFFSET %s',
+    orderByColumn,
+    orderByDirection,
+    limit,
+    offset
   );
+  logger.info(`Executed query: ${querySelectAllJoyasWithParams}`);
 
   const { rows: countAllResult } = await pool.query(queryCountAllJoyas);
   const { rows: joyas } = await pool.query(querySelectAllJoyasWithParams);
@@ -62,11 +63,8 @@ export const getAllJoyasModel = async ({ limits, page, orderBy } = {}) => {
  * @returns {Promise<Array>} Array con la(s) fila(s) de la joya encontrada.
  */
 export const getJoyaByIdModel = async (id) => {
-  const query = {
-    text: 'SELECT * FROM inventario WHERE id = $1',
-    values: [id],
-  };
-  logger.info(`Executed query: SELECT * FROM inventario WHERE id = ${id}`);
+  const query = format('SELECT * FROM inventario WHERE id = %s', id);
+  logger.info(`Executed query: ${query}`);
 
   const { rows: results } = await pool.query(query);
 


### PR DESCRIPTION
Este Pull Request introduce una refactorización en el manejo de consultas SQL, incorporando el uso de la dependencia [pg-format](https://www.npmjs.com/package/pg-format). El objetivo principal de este cambio es mejorar la legibilidad, seguridad y mantenibilidad del código, evitando la concatenación manual de valores en las consultas.

No se realizaron modificaciones en la lógica de negocio ni en la estructura de los endpoints, por lo que no se afecta el comportamiento actual de la API.